### PR TITLE
make sure my.cnf is not world writable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Ben Firshman <ben@orchardup.com>
 RUN apt-get update -qq && apt-get install -y mysql-server-5.5
 
 ADD my.cnf /etc/mysql/conf.d/my.cnf
+RUN chmod 664 /etc/mysql/conf.d/my.cnf
 ADD run /usr/local/bin/run
 RUN chmod +x /usr/local/bin/run
 


### PR DESCRIPTION
I'm on Windows and running docker through Vagrant and a VirtualBox VM. I share my workspace folder between my host (Windows) and the VM running docker. As a result all files in that shared folder are 777.

When building the orchardup/mysql image from this folder, the `my.cnf` file ends up to be world-writable within the docker image. As a result mysqld fails to load the `my.cnf` file as you can see in the log:

```
vagrant@vagrant:/tmp/docker-mysql$ docker run test/mysql
Warning: World-writable config file '/etc/mysql/conf.d/my.cnf' is ignored
Warning: World-writable config file '/etc/mysql/conf.d/my.cnf' is ignored
140219 23:06:56 [Warning] Using unique option prefix key_buffer instead of key_buffer_size is deprecated and will be removed in a future release. Please use the full name instead.
Warning: World-writable config file '/etc/mysql/conf.d/my.cnf' is ignored
140219 23:06:56 [Warning] Using unique option prefix key_buffer instead of key_buffer_size is deprecated and will be removed in a future release. Please use the full name instead.
Warning: World-writable config file '/etc/mysql/conf.d/my.cnf' is ignored
140219 23:06:56 [Warning] Using unique option prefix key_buffer instead of key_buffer_size is deprecated and will be removed in a future release. Please use the full name instead.
Warning: World-writable config file '/etc/mysql/conf.d/my.cnf' is ignored
140219 23:06:58 [Warning] Using unique option prefix key_buffer instead of key_buffer_size is deprecated and will be removed in a future release. Please use the full name instead.
```

[full log](https://gist.github.com/thomasleveil/9103620) to reproduce the issue

This pull request modifies the `Dockerfile` to make sure the `my.cnf` won't be world-writable in the docker image.
