### PR TITLE
Fix mysqldump binlogging not active error.

### DIFF
--- a/my.cnf
+++ b/my.cnf
@@ -4,3 +4,4 @@ console=1
 general_log=1
 general_log_file=/dev/stdout
 log_error=/dev/stderr
+log-bin=mysql-bin


### PR DESCRIPTION
Running mysqldump throws "mysqldump: Error: Binlogging on server not active".
Adding the log-bin option should fix this.
