### PR TITLE
Added support to run MySQL on RAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Includes a bunch of cool features such as:
  - Setting a root password.
  - Creating a user and database.
  - Passing extra parameters to mysqld.
+ - Running MySQL on RAM (datadir mounted on tmpfs)
 
 Here's how it works:
 
@@ -42,4 +43,5 @@ Environment variables
  - `MYSQL_USER`: A user to create that has access to the database specified by `MYSQL_DATABASE`.
  - `MYSQL_PASSWORD`: The password for `MYSQL_USER`. Defaults to a blank password.
  - `MYSQLD_ARGS`: extra parameters to pass to the mysqld process
- 
+ - `MYSQLD_RAM`: Turn on tmpfs datadir mounting. Defaults to 0.
+ - `MYSQLD_RAM_SIZE`: tmpfs datadir size in megabytes. Defaults to 256.

--- a/run
+++ b/run
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -e
 
+MYSQL_RAM=${MYSQL_RAM:-"0"}
+MYSQL_RAM_SIZE=${MYSQL_RAM_SIZE:-"256"}
+
+if [[ "$MYSQL_RAM" != "0" ]]; then
+    echo "Mounting MySQL with ${MYSQL_RAM_SIZE}MB of RAM."
+    mkdir -p /var/lib/mysql
+    mount -t tmpfs -o size="${MYSQL_RAM_SIZE}m" tmpfs /var/lib/mysql
+fi
+
 chown -R mysql:mysql /var/lib/mysql
 mysql_install_db --user mysql > /dev/null
 


### PR DESCRIPTION
I've added support to mount the MySQL datadir into an tmpfs partition. This is useful to run test suites against MySQL faster.

Here is how it works:

`MYSQL_RAM=1` turns on the feature.
`MYSQL_RAM_SIZE` defines the amount of RAM allowed.

Note: this requires container extended privileges (-privileged), otherwise an `Permission denied` error occurs.

Example:

```
docker run -e MYSQL_RAM=1 -e MYSQL_RAM_SIZE=256 --privileged -d --name mysql-ram orchardup/mysql
```
