### PR TITLE
Unattended apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM stackbrew/ubuntu:12.04
 MAINTAINER Ben Firshman <ben@orchardup.com>
 
+ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -qq && apt-get install -y mysql-server-5.5
 
 ADD my.cnf /etc/mysql/conf.d/my.cnf


### PR DESCRIPTION
Added DEBIAN_FRONTEND environment variable with the value "noninteractive" to make apt unattended and get rid of some ugly errors in the log.
